### PR TITLE
examples: dts: fix reserved memory nodes for core1 rpmsg

### DIFF
--- a/examples/linux/dts/xilinx/.gitignore
+++ b/examples/linux/dts/xilinx/.gitignore
@@ -1,4 +1,7 @@
 # These files come from a copy command in the Makefile
 # don't check them in even though they look like source files
 
+zynqmp-zcu102-rev1.0.dts
+zynqmp-smk-k26-revA.dts
 zynqmp-sck-kv-g-revB.dtso
+.linux-src-check

--- a/examples/linux/dts/xilinx/Makefile
+++ b/examples/linux/dts/xilinx/Makefile
@@ -3,9 +3,10 @@
 DTBS := zcu102-openamp-lockstep.dtb zcu102-openamp-split.dtb
 DTBS += kria-openamp-lockstep.dtb kria-openamp-split.dtb
 DTBS += zynqmp-smk-k26-revA.dtb zynqmp-zcu102-rev1.0.dtb
+DTBS += zcu102-xilinx-bm-lockstep.dtb kv260-xilinx-bm-lockstep.dtb
 
 DTBOS := zynqmp-split.dtbo zcu102-openamp.dtbo zynqmp-openamp.dtbo
-DTBOS += zynqmp-sck-kv-g-revB.dtbo
+DTBOS += zynqmp-sck-kv-g-revB.dtbo xilinx-openamp-for-v6.5.dtbo
 
 # any file to test we have a valid kernel source dir
 XILINX_DTS_DIR := $(LINUX_SRC_DIR)/arch/arm64/boot/dts/xilinx
@@ -84,6 +85,17 @@ kv260-openamp-split.dtb: \
 	zynqmp-smk-k26-revA.dtb zynqmp-sck-kv-g-revB.dtbo \
 	zynqmp-openamp.dtbo \
 	zynqmp-split.dtbo
+	fdtoverlay -o $@ -i $(filter-out .linux-src-check,$^)
+
+zcu102-xilinx-bm-lockstep.dtb: \
+	zynqmp-zcu102-rev1.0.dtb \
+	xilinx-openamp-for-v6.5.dtbo \
+	zcu102-openamp.dtb0
+	fdtoverlay -o $@ -i $(filter-out .linux-src-check,$^)
+
+kv260-xilinx-bm-lockstep.dtb: \
+	zynqmp-smk-k26-revA.dtb zynqmp-sck-kv-g-revB.dtbo \
+	xilinx-openamp-for-v6.5.dtbo
 	fdtoverlay -o $@ -i $(filter-out .linux-src-check,$^)
 
 clean:

--- a/examples/linux/dts/xilinx/Makefile
+++ b/examples/linux/dts/xilinx/Makefile
@@ -64,11 +64,13 @@ zynqmp-sck-kv-g-revB.dtso: $(XILINX_DTS_DIR)/zynqmp-sck-kv-g-revB.dtso
 
 zcu102-openamp-lockstep.dtb: \
 	zynqmp-zcu102-rev1.0.dtb \
+	zynqmp-openamp.dtbo \
 	zcu102-openamp.dtbo
 	fdtoverlay -o $@ -i $(filter-out .linux-src-check,$^)
 
 zcu102-openamp-split.dtb: \
 	zynqmp-zcu102-rev1.0.dtb \
+	zynqmp-openamp.dtbo \
 	zcu102-openamp.dtbo \
 	zynqmp-split.dtbo
 	fdtoverlay -o $@ -i $(filter-out .linux-src-check,$^)

--- a/examples/linux/dts/xilinx/Makefile
+++ b/examples/linux/dts/xilinx/Makefile
@@ -2,12 +2,10 @@
 
 DTBS := zcu102-openamp-lockstep.dtb zcu102-openamp-split.dtb
 DTBS += kria-openamp-lockstep.dtb kria-openamp-split.dtb
+DTBS += zynqmp-smk-k26-revA.dtb zynqmp-zcu102-rev1.0.dtb
 
-#DTBOS := zynqmp-split.dtbo
-
-# DTBC = DTBs as a result of combining a base with one or more overlays
-DTBCS := kv260-openamp-lockstep.dtb kv260-openamp-split.dtb
-
+DTBOS := zynqmp-split.dtbo zcu102-openamp.dtbo zynqmp-openamp.dtbo
+DTBOS += zynqmp-sck-kv-g-revB.dtbo
 
 # any file to test we have a valid kernel source dir
 XILINX_DTS_DIR := $(LINUX_SRC_DIR)/arch/arm64/boot/dts/xilinx
@@ -17,18 +15,20 @@ SHELL := /bin/bash
 
 all: $(DTBS) $(DTBOS) $(DTBCS)
 
-check-linux-dir:
+.linux-src-check:
 	@if [ ! -d $(XILINX_DTS_DIR) ]; then \
 		echo "LINUX_SRC_DIR must point to a Linux source directory"; \
 		echo "LINUX_SRC_DIR=$(LINUX_SRC_DIR)"; \
 		exit 2; \
 	fi
+	touch .linux-src-check
 
-.PHONY : all check-linux-dir
+.PHONY : all
 
 DTC_CPP_FLAGS= -E -x assembler-with-cpp -nostdinc -undef -D__DTS__
 
 # Note: -@ includes symbols which is need to apply overlays
+# We always enable overlays
 %.dtb: %.dts
 	# Linux DTS uses C preprocessor first
 	$(CC) $(DTC_CPP_FLAGS) \
@@ -45,16 +45,44 @@ DTC_CPP_FLAGS= -E -x assembler-with-cpp -nostdinc -undef -D__DTS__
 		-o $<.pp $<
 	dtc -@ -I dts -O dtb -o $@ $<.pp
 
-$(DTBS): check-linux-dir
+DTB_KERNEL_SRC := \
+	zynqmp-zcu102-rev1.0.dts \
+	zynqmp-smk-k26-revA.dts \
+	zynqmp-sck-kv-g-revB.dtso
+
+$(DTBS) $(DTBOS) $(DTB_KERNEL_SRC):  .linux-src-check
+
+# copy needed sources from Kernel
+zynqmp-zcu102-rev1.0.dts: $(XILINX_DTS_DIR)/zynqmp-zcu102-rev1.0.dts
+	cp $< $@
+
+zynqmp-smk-k26-revA.dts: $(XILINX_DTS_DIR)/zynqmp-smk-k26-revA.dts
+	cp $< $@
 
 zynqmp-sck-kv-g-revB.dtso: $(XILINX_DTS_DIR)/zynqmp-sck-kv-g-revB.dtso
 	cp $< $@
 
-kv260-openamp-lockstep.dtb: kria-openamp-lockstep.dtb zynqmp-sck-kv-g-revB.dtbo
-	fdtoverlay -o $@ -i $^
+zcu102-openamp-lockstep.dtb: \
+	zynqmp-zcu102-rev1.0.dtb \
+	zcu102-openamp.dtbo
+	fdtoverlay -o $@ -i $(filter-out .linux-src-check,$^)
 
-kv260-openamp-split.dtb: kria-openamp-split.dtb zynqmp-sck-kv-g-revB.dtbo
-	fdtoverlay -o $@ -i $^
+zcu102-openamp-split.dtb: \
+	zynqmp-zcu102-rev1.0.dtb \
+	zcu102-openamp.dtbo \
+	zynqmp-split.dtbo
+	fdtoverlay -o $@ -i $(filter-out .linux-src-check,$^)
+
+kv260-openamp-lockstep.dtb: \
+	zynqmp-smk-k26-revA.dtb zynqmp-sck-kv-g-revB.dtbo \
+	zynqmp-openamp.dtbo
+	fdtoverlay -o $@ -i $(filter-out .linux-src-check,$^)
+
+kv260-openamp-split.dtb: \
+	zynqmp-smk-k26-revA.dtb zynqmp-sck-kv-g-revB.dtbo \
+	zynqmp-openamp.dtbo \
+	zynqmp-split.dtbo
+	fdtoverlay -o $@ -i $(filter-out .linux-src-check,$^)
 
 clean:
-	rm -f $(DTBS) $(DTBOS) $(DTBCS) *.pp
+	rm -f $(DTBS) $(DTBOS) $(DTBCS) *.pp .linux-src-check $(DTB_KERNEL_SRC)

--- a/examples/linux/dts/xilinx/kria-openamp-lockstep.dts
+++ b/examples/linux/dts/xilinx/kria-openamp-lockstep.dts
@@ -1,8 +1,0 @@
-/* A base DTB for all kria for lockstep mode
-** A carrier card overlay will be applied to this dtb,
-** either at compile or at boot time
-*/
-
-#include "zynqmp-smk-k26-revA.dts"
-#include "zynqmp-openamp.dtsi"
-

--- a/examples/linux/dts/xilinx/kria-openamp-split.dts
+++ b/examples/linux/dts/xilinx/kria-openamp-split.dts
@@ -1,9 +1,0 @@
-/* A base DTB for all kria for split mode
-** A carrier card overlay will be applied to this dtb,
-** either at compile or at boot time
-*/
-
-#include "zynqmp-smk-k26-revA.dts"
-#include "zynqmp-openamp.dtsi"
-#include "zynqmp-split.dtsi"
-

--- a/examples/linux/dts/xilinx/xilinx-openamp-for-v6.5.dtso
+++ b/examples/linux/dts/xilinx/xilinx-openamp-for-v6.5.dtso
@@ -1,0 +1,112 @@
+/* Applies to all zynqmp boards to configure the IPC & memory for OpenAMP */
+
+/dts-v1/;
+/plugin/;
+
+&{/} {
+	#address-cells = <2>;
+	#size-cells = <2>;
+
+	reserved-memory {
+		#address-cells = <0x02>;
+		#size-cells = <0x02>;
+		ranges;
+
+		rproc_0_fw_image: memory@3ed00000 {
+			no-map;
+			reg = <0x0 0x3ed00000 0x0 0x40000>;
+		};
+
+		rpu0vdev0vring0: vdev0vring0@3ed40000 {
+			no-map;
+			reg = <0x00 0x3ed40000 0x00 0x4000>;
+		};
+
+		rpu0vdev0vring1: vdev0vring1@3ed44000 {
+			no-map;
+			reg = <0x00 0x3ed44000 0x00 0x4000>;
+		};
+
+		rpu0vdev0buffer: vdev0buffer@3ed48000 {
+			no-map;
+			compatible = "shared-dma-pool";
+			reg = <0x00 0x3ed48000 0x00 0x100000>;
+		};
+
+	};
+
+	zynqmp_ipi1 {
+		compatible = "xlnx,zynqmp-ipi-mailbox";
+		interrupt-parent = <&gic>;
+		interrupts = <0x00 0x1d 0x04>;
+		xlnx,ipi-id = <0x07>;
+		#address-cells = <0x01>;     			/* <------ 1 vs 2 below */
+		#size-cells = <0x01>;
+		ranges;
+
+		ipi_mailbox_rpu0: mailbox@ff990600 {
+			reg = <0xff990600 0x20>, 
+			      <0xff990620 0x20>, 
+			      <0xff9900c0 0x20>, 
+			      <0xff9900e0 0x20>;
+			reg-names = "local_request_region",
+			            "local_response_region",
+				    "remote_request_region",
+				    "remote_response_region";
+			#mbox-cells = <0x01>;
+			xlnx,ipi-id = <0x01>;			/* <---- 1 vs 7 ?? */
+		};
+	};
+
+#if 0
+	zynqmp_ipi {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		ipi_mailbox_rpu0: mailbox@ff990040 {
+			reg = <0x00 0xff990040 0x00 0x20>,
+			      <0x00 0xff990060 0x00 0x20>,
+			      <0x00 0xff990200 0x00 0x20>,
+			      < 0x00 0xff990220 0x00 0x20>;
+			reg-names = "local_request_region",
+				    "local_response_region",
+				    "remote_request_region",
+				    "remote_response_region";
+			#mbox-cells = <0x01>;
+			xlnx,ipi-id = <0x01>;
+		};
+
+		ipi_mailbox_rpu1: mailbox@ff990080 {
+			reg = <0x00 0xff990420 0x00 0x20>,
+			      <0x00 0xff990440 0x00 0x20>,
+			      <0x00 0xff990260 0x00 0x20>,
+			      <0x00 0xff990280 0x00 0x20>;
+			reg-names = "local_request_region",
+				    "local_response_region",
+				    "remote_request_region",
+				    "remote_response_region";
+			#mbox-cells = <0x01>;
+			xlnx,ipi-id = <0x02>;
+		};
+	};
+#endif
+
+	remoteproc: remoteproc {
+		r5f-0 {
+			memory-region = <&rproc_0_fw_image>, <&rpu0vdev0vring0>,
+					<&rpu0vdev0vring1>, <&rpu0vdev0buffer>;
+			mboxes = <&ipi_mailbox_rpu0 0>, <&ipi_mailbox_rpu0 1>;
+			mbox-names = "tx", "rx";
+		};
+
+#if 0
+		r5f-1 {
+			memory-region = <&rproc_1_fw_image>, <&rpu1vdev1vring0>,
+					<&rpu1vdev1vring1>, <&rpu1vdev1buffer>;
+			mboxes = <&ipi_mailbox_rpu1 0>, <&ipi_mailbox_rpu1 1>;
+			mbox-names = "tx", "rx";
+		};
+#endif
+	};
+};

--- a/examples/linux/dts/xilinx/xilinx-openamp.dtso
+++ b/examples/linux/dts/xilinx/xilinx-openamp.dtso
@@ -1,0 +1,133 @@
+/dts-v1/;
+
+/ {
+
+	fragment@0 {
+		target-path = "/";
+
+		__overlay__ {
+
+			reserved-memory {
+				#address-cells = <0x02>;
+				#size-cells = <0x02>;
+				ranges;
+
+				rpu0vdev0vring0@3ed40000 {
+					no-map;
+					reg = <0x00 0x3ed40000 0x00 0x4000>;
+					phandle = <0x05>;
+				};
+
+				rpu0vdev0vring1@3ed44000 {
+					no-map;
+					reg = <0x00 0x3ed44000 0x00 0x4000>;
+					phandle = <0x06>;
+				};
+
+				rpu0vdev0buffer@3ed48000 {
+					no-map;
+					reg = <0x00 0x3ed48000 0x00 0x100000>;
+					phandle = <0x04>;
+				};
+
+				rproc@3ed00000 {
+					no-map;
+					reg = <0x00 0x3ed00000 0x00 0x40000>;
+					phandle = <0x03>;
+				};
+			};
+
+			tcm_0a@ffe00000 {
+				no-map;
+				reg = <0x00 0xffe00000 0x00 0x10000>;
+				status = "okay";
+				compatible = "mmio-sram";
+				power-domain = <0xffffffff 0x0f>;
+				phandle = <0x01>;
+			};
+
+			tcm_0b@ffe20000 {
+				no-map;
+				reg = <0x00 0xffe20000 0x00 0x10000>;
+				status = "okay";
+				compatible = "mmio-sram";
+				power-domain = <0xffffffff 0x10>;
+				phandle = <0x02>;
+			};
+
+			rf5ss@ff9a0000 {
+				compatible = "xlnx,zynqmp-r5-remoteproc";
+				xlnx,cluster-mode = <0x01>;
+				ranges;
+				reg = <0x00 0xff9a0000 0x00 0x10000>;
+				#address-cells = <0x02>;
+				#size-cells = <0x02>;
+
+				r5f@0 {
+					compatible = "xilinx,r5f";
+					#address-cells = <0x02>;
+					#size-cells = <0x02>;
+					ranges;
+					sram = <0x01 0x02>;
+					memory-region = <0x03 0x04 0x05 0x06>;
+					power-domain = <0xffffffff 0x07>;
+					mboxes = <0x07 0x00 0x07 0x01>;
+					mbox-names = "tx\0rx";
+					phandle = <0x08>;
+				};
+			};
+
+			zynqmp_ipi1 {
+				compatible = "xlnx,zynqmp-ipi-mailbox";
+				interrupt-parent = <0xffffffff>;
+				interrupts = <0x00 0x1d 0x04>;
+				xlnx,ipi-id = <0x07>;
+				#address-cells = <0x01>;
+				#size-cells = <0x01>;
+				ranges;
+
+				mailbox@ff990600 {
+					reg = <0xff990600 0x20 0xff990620 0x20 0xff9900c0 0x20 0xff9900e0 0x20>;
+					reg-names = "local_request_region\0local_response_region\0remote_request_region\0remote_response_region";
+					#mbox-cells = <0x01>;
+					xlnx,ipi-id = <0x01>;
+					phandle = <0x07>;
+				};
+			};
+		};
+	};
+
+	__symbols__ {
+		rpu0vdev0vring0 = "/fragment@0/__overlay__/reserved-memory/rpu0vdev0vring0@3ed40000";
+		rpu0vdev0vring1 = "/fragment@0/__overlay__/reserved-memory/rpu0vdev0vring1@3ed44000";
+		rpu0vdev0buffer = "/fragment@0/__overlay__/reserved-memory/rpu0vdev0buffer@3ed48000";
+		rproc_0_reserved = "/fragment@0/__overlay__/reserved-memory/rproc@3ed00000";
+		tcm_0a = "/fragment@0/__overlay__/tcm_0a@ffe00000";
+		tcm_0b = "/fragment@0/__overlay__/tcm_0b@ffe20000";
+		r5f_0 = "/fragment@0/__overlay__/rf5ss@ff9a0000/r5f@0";
+		ipi_mailbox_rpu0 = "/fragment@0/__overlay__/zynqmp_ipi1/mailbox@ff990600";
+	};
+
+	__fixups__ {
+		zynqmp_firmware = "/fragment@0/__overlay__/tcm_0a@ffe00000:power-domain:0\0/fragment@0/__overlay__/tcm_0b@ffe20000:power-domain:0\0/fragment@0/__overlay__/rf5ss@ff9a0000/r5f@0:power-domain:0";
+		gic = "/fragment@0/__overlay__/zynqmp_ipi1:interrupt-parent:0";
+	};
+
+	__local_fixups__ {
+
+		fragment@0 {
+
+			__overlay__ {
+
+				rf5ss@ff9a0000 {
+
+					r5f@0 {
+						sram = <0x00 0x04>;
+						memory-region = <0x00 0x04 0x08 0x0c>;
+						mboxes = <0x00 0x08>;
+					};
+				};
+			};
+		};
+	};
+};

--- a/examples/linux/dts/xilinx/zcu102-openamp-base.dtsi
+++ b/examples/linux/dts/xilinx/zcu102-openamp-base.dtsi
@@ -1,9 +1,0 @@
-/* Changes specific to zcu102 but common to mode */
-
-/ {
-	axi {
-		serial@ff010000 {
-			status = "disabled";
-		};
-	};
-};

--- a/examples/linux/dts/xilinx/zcu102-openamp-lockstep.dts
+++ b/examples/linux/dts/xilinx/zcu102-openamp-lockstep.dts
@@ -1,6 +1,0 @@
-/* A complete DTB for zcu102 in lockstep mode */
-
-#include "zynqmp-zcu102-rev1.0.dts"
-#include "zcu102-openamp-base.dtsi"
-#include "zynqmp-openamp.dtsi"
-

--- a/examples/linux/dts/xilinx/zcu102-openamp-split.dts
+++ b/examples/linux/dts/xilinx/zcu102-openamp-split.dts
@@ -1,6 +1,0 @@
-/* A complete DTB for zcu102 in split mode */
-
-#include "zynqmp-zcu102-rev1.0.dts"
-#include "zcu102-openamp-base.dtsi"
-#include "zynqmp-openamp.dtsi"
-#include "zynqmp-split.dtsi"

--- a/examples/linux/dts/xilinx/zcu102-openamp.dtso
+++ b/examples/linux/dts/xilinx/zcu102-openamp.dtso
@@ -1,0 +1,11 @@
+/* Changes specific to zcu102 but common to mode */
+
+/* include everything from generic zynqmp-openamp overlay */
+#include "zynqmp-openamp.dtso"
+
+/* Plus make these specific zcu102 changes */
+&{/axi} {
+	serial@ff010000 {
+		status = "disabled";
+	};
+};

--- a/examples/linux/dts/xilinx/zynqmp-openamp.dtso
+++ b/examples/linux/dts/xilinx/zynqmp-openamp.dtso
@@ -38,17 +38,17 @@
 			reg = <0x0 0x3ef00000 0x0 0x40000>;
 		};
 
-		rpu1vdev1vring0: vdev1vring0@3ef40000 {
+		rpu1vdev0vring0: vdev0vring0@3ef40000 {
 			no-map;
 			reg = <0x00 0x3ef40000 0x00 0x4000>;
 		};
 
-		rpu1vdev1vring1: vdev1vring1@3ef44000 {
+		rpu1vdev0vring1: vdev0vring1@3ef44000 {
 			no-map;
 			reg = <0x00 0x3ef44000 0x00 0x4000>;
 		};
 
-		rpu1vdev1buffer: vdev1buffer@3ef48000 {
+		rpu1vdev0buffer: vdev0buffer@3ef48000 {
 			no-map;
 			compatible = "shared-dma-pool";
 			reg = <0x00 0x3ef48000 0x00 0x100000>;
@@ -96,8 +96,8 @@
 		};
 
 		r5f-1 {
-			memory-region = <&rproc_1_fw_image>, <&rpu1vdev1vring0>,
-					<&rpu1vdev1vring1>, <&rpu1vdev1buffer>;
+			memory-region = <&rproc_1_fw_image>, <&rpu1vdev0vring0>,
+					<&rpu1vdev0vring1>, <&rpu1vdev0buffer>;
 			mboxes = <&ipi_mailbox_rpu1 0>, <&ipi_mailbox_rpu1 1>;
 			mbox-names = "tx", "rx";
 		};

--- a/examples/linux/dts/xilinx/zynqmp-openamp.dtso
+++ b/examples/linux/dts/xilinx/zynqmp-openamp.dtso
@@ -1,6 +1,12 @@
 /* Applies to all zynqmp boards to configure the IPC & memory for OpenAMP */
 
-/ {
+/dts-v1/;
+/plugin/;
+
+&{/} {
+	#address-cells = <2>;
+	#size-cells = <2>;
+
 	reserved-memory {
 		#address-cells = <0x02>;
 		#size-cells = <0x02>;
@@ -50,6 +56,10 @@
 	};
 
 	zynqmp_ipi {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
 		ipi_mailbox_rpu0: mailbox@ff990040 {
 			reg = <0x00 0xff990040 0x00 0x20>,
 			      <0x00 0xff990060 0x00 0x20>,

--- a/examples/linux/dts/xilinx/zynqmp-split.dtsi
+++ b/examples/linux/dts/xilinx/zynqmp-split.dtsi
@@ -1,8 +1,0 @@
-/* Applies to all zynqmp boards to select split mode */
-
-/ {
-    remoteproc: remoteproc {
-	    xlnx,cluster-mode = <0>;
-    };
-};
-

--- a/examples/linux/dts/xilinx/zynqmp-split.dtso
+++ b/examples/linux/dts/xilinx/zynqmp-split.dtso
@@ -1,0 +1,9 @@
+/* Applies to all zynqmp boards to select split mode */
+
+/dts-v1/;
+/plugin/;
+
+&remoteproc {
+	xlnx,cluster-mode = <0>;
+};
+


### PR DESCRIPTION
Xilinx remoteproc driver expects node name to be vdev0vringx and vdev0buffer. Remoteproc framework will add memory carveouts based on these names. Fix current node names for core1 rpmsg accordingly.